### PR TITLE
Force text renderen in datatables

### DIFF
--- a/views/geekbench_listing.php
+++ b/views/geekbench_listing.php
@@ -53,7 +53,7 @@ new Geekbench_model;
 		var columnDefs = [],
             col = 0; // Column counter
 		$('.table th').map(function(){
-              columnDefs.push({name: $(this).data('colname'), targets: col});
+              columnDefs.push({name: $(this).data('colname'), targets: col, render: $.fn.dataTable.render.text()});
               col++;
 		});
 	    oTable = $('.table').dataTable( {


### PR DESCRIPTION
Update to force the text() renderer for all fields.